### PR TITLE
Fixes failure on 'lineman run' watch task

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
     var taskDone = this.async();
     // Get a list of files to be watched.
     var patterns = grunt.util._.pluck(targets, 'files');
-    var getFiles = function() { return grunt.file.expand({filter: 'isFile'}, patterns); }
+    var getFiles = function() { return grunt.file.expand({filter: 'isFile', cwd: process.cwd()}, patterns); }
     // This task's name + optional args, in string format.
     var nameArgs = this.nameArgs;
     // An ID by which the setInterval can be canceled.


### PR DESCRIPTION
Running watch task
Waiting...Warning: Arguments to path.join must be strings Use --force to continue.
