### PR TITLE
Add livereload options

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,15 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "gaze": "0.3.3"
+    "gaze": "0.3.3",
+    "tiny-lr-fork": "0.0.5"
   },
   "devDependencies": {
     "grunt": "0.4.0"
   },
   "keywords": [
-    "gruntplugin", "watch", "lineman"
+    "gruntplugin",
+    "watch",
+    "lineman"
   ]
 }

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -1,0 +1,58 @@
+/*
+ * grunt-contrib-watch
+ * http://gruntjs.com/
+ *
+ * Copyright (c) 2014 "Cowboy" Ben Alman, contributors
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var tinylr = require('tiny-lr-fork');
+var _ = require('lodash');
+
+// Holds the servers out of scope in case watch is reloaded
+var servers = Object.create(null);
+
+module.exports = function(grunt) {
+
+  var defaults = { port: 35729 };
+
+  function LR(options) {
+    if (options === true) {
+      options = defaults;
+    } else if (typeof options === 'number') {
+      options = {port: options};
+    } else {
+      options = _.defaults(options, defaults);
+    }
+    if (servers[options.port]) {
+      this.server = servers[options.port];
+    } else {
+      this.server = tinylr(options);
+      this.server.server.removeAllListeners('error');
+      this.server.server.on('error', function(err) {
+        if (err.code === 'EADDRINUSE') {
+          grunt.fatal('Port ' + options.port + ' is already in use by another process.');
+        } else {
+          grunt.fatal(err);
+        }
+        process.exit(1);
+      });
+      this.server.listen(options.port, function(err) {
+        if (err) { return grunt.fatal(err); }
+        grunt.log.verbose.writeln('Live reload server started on port: ' + options.port);
+      });
+      servers[options.port] = this.server;
+    }
+  }
+
+  LR.prototype.trigger = function(files) {
+    grunt.log.verbose.writeln('Live reloading ' + grunt.log.wordlist(files) + '...');
+    this.server.changed({body:{files:files}});
+  };
+
+  return function(options) {
+    return new LR(options);
+  };
+};

--- a/tasks/lib/livereload.js
+++ b/tasks/lib/livereload.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var tinylr = require('tiny-lr-fork');
-var _ = require('lodash');
 
 // Holds the servers out of scope in case watch is reloaded
 var servers = Object.create(null);
@@ -24,7 +23,7 @@ module.exports = function(grunt) {
     } else if (typeof options === 'number') {
       options = {port: options};
     } else {
-      options = _.defaults(options, defaults);
+      options.port = options.port || defaults.port;
     }
     if (servers[options.port]) {
       this.server = servers[options.port];

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -16,35 +16,24 @@ module.exports = function(grunt) {
   var mtimes = {};
 
   grunt.registerTask('watch', 'Run predefined tasks whenever watched files change.', function(target) {
-    this.requiresConfig('watch');
+    var taskName = this.name; //'watch'
+    this.requiresConfig(taskName);
     // Build an array of files/tasks objects.
-    var watch = grunt.config('watch');
+    var watch = grunt.config(taskName);
     var targets = target ? [target] : Object.keys(watch).filter(function(key) {
       return typeof watch[key] !== 'string' && !Array.isArray(watch[key]);
     });
 
-    //-- Nasty live reloader hacks
-    var liveReloaders = {},
-        defaultLiveReloader,
-        taskLRConfig = grunt.config([self.name, 'options', 'livereload']);
+    var livereload,
+        taskLRConfig = grunt.config([taskName, 'options', 'livereload']);
     if(taskLRConfig) {
-      defaultLiveReloader = require('./lib/livereload')(grunt)(taskLRConfig);
+      livereload = require('./lib/livereload')(grunt)(taskLRConfig);
     }
-    var createLiveReloaderFor = function(target) {
-      // If a default livereload server for all targets
-      // Use task level unless target level overrides
-      var targetLRConfig = grunt.config([self.name, target, 'options', 'livereload']);
-      if (targetLRConfig || taskLRConfig) {
-        liveReloaders[target] = targetLRConfig ? require('./lib/livereload')(grunt)(targetLRConfig) : defaultLiveReloader;
-      }
-    };
-    //-- / Nasty livereloader hacks
 
     targets = targets.map(function(target) {
       // Fail if any required config properties have been omitted.
-      target = ['watch', target];
+      target = [taskName, target];
       this.requiresConfig(target.concat('files'), target.concat('tasks'));
-      createLiveReloaderFor(target)
       return grunt.config(target);
     }, this);
 

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     // Build an array of files/tasks objects.
     var watch = grunt.config(taskName);
     var targets = target ? [target] : Object.keys(watch).filter(function(key) {
-      return typeof watch[key] !== 'string' && !Array.isArray(watch[key]);
+      return typeof watch[key] !== 'string' && !Array.isArray(watch[key]) && key !== "options";
     });
 
     var livereload,


### PR DESCRIPTION
To use this feature, just add livereload options. They're pretty much directly aped from the base fork, so see [its documentation](https://github.com/gruntjs/grunt-contrib-watch#optionslivereload) for the gist 

Also note that because of how this branch operates on all tasks at once, there's no target-level config support for livereload. That means you **must** define a single livereload option at the top of your `watch` config like so:

```
    watch: {
      options: {
        livereload: true
      }
```

Proof of life:
![livereload](https://cloud.githubusercontent.com/assets/79303/3351921/020ad1ee-fa26-11e3-8277-6fa1154e054e.gif)
