### PR TITLE
Livereload triggered after tasks.

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -84,6 +84,12 @@ module.exports = function(grunt) {
         // Clear the modified file's cached require data.
         clearRequireCache(filepath);
       });
+      
+      //Add trigger to grunt task so it is possible to que livereload after e.g. Sass compile
+      grunt.registerTask('livereloadTrigger', function() {
+-               livereload.trigger(fileArray);
+-     });
+
       // Unwatch all watched files.
       Object.keys(watchedFiles).forEach(unWatchFile);
       // For each specified target, test to see if any files matching that
@@ -96,10 +102,7 @@ module.exports = function(grunt) {
           grunt.task.run(target.tasks).mark();
           // Trigger livereload if necessary
           if(livereload){
-            grunt.registerTask('livereload', function() {
-               livereload.trigger(fileArray);
-            });
-            grunt.task.run('livereload');
+            grunt.task.run('livereloadTrigger');
           };
         }
       });

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -87,8 +87,8 @@ module.exports = function(grunt) {
       
       //Add trigger to grunt task so it is possible to que livereload after e.g. Sass compile
       grunt.registerTask('livereloadTrigger', function() {
--               livereload.trigger(fileArray);
--     });
+        livereload.trigger(fileArray);
+      });
 
       // Unwatch all watched files.
       Object.keys(watchedFiles).forEach(unWatchFile);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -94,15 +94,18 @@ module.exports = function(grunt) {
         // Enqueue specified tasks if at least one matching file was found.
         if (files.length > 0 && target.tasks) {
           grunt.task.run(target.tasks).mark();
+          // Trigger livereload if necessary
+          if(livereload){
+            grunt.registerTask('livereload', function() {
+               livereload.trigger(fileArray);
+            });
+            grunt.task.run('livereload');
+          };
         }
       });
       // Enqueue the watch task, so that it loops.
       grunt.task.run(nameArgs);
       // Continue task queue.
-      // Trigger livereload if necessary
-      if (livereload) {
-        livereload.trigger(fileArray);
-      }
 
       taskDone();
     }, 250);


### PR DESCRIPTION
Livereload trigger added to queue as a task. 

I've noticed problem with triggering livereload before .scss compile and concat done, so changes was not visible after livereload browser refresh, so I had to reload again or save file twice to trigger livereload again, witch was pretty annoying..
I'm newbie in Grunt and Lineman so I'm not sure is this is a good solution or is my understanding of the problem is correct. But that works for me. ;)
